### PR TITLE
Move functionality into Ka3005p object

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,10 @@
 name: Rust
 
-on:
+on: 
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+  release:
+    types: [published]
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,14 +13,66 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [x86_64-pc-windows-gnu, x86_64-unknown-linux-musl, arm-unknown-linux-musleabihf]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install system dependencies
-      run: sudo apt-get install pkg-config libudev-dev
-    - name: Build
-      run: cargo build --all-targets --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Lint 
-      run: cargo clippy
+
+    - name: Build Binary
+      uses: actions-rs/cargo@v1
+      with:
+          use-cross: true
+          command: build
+          args: --target ${{ matrix.os }} --release
+
+    - name: Save Artifact
+      uses: actions/upload-artifact@v2
+      if: matrix.os != 'x86_64-pc-windows-gnu'
+      with:
+        name: ka3005p-${{ matrix.os }}
+        path: target/${{ matrix.os }}/release/ka3005p
+        
+    - name: Save Windows Artifact
+      uses: actions/upload-artifact@v2
+      if: matrix.os == 'x86_64-pc-windows-gnu'
+      with:
+        name: ka3005p-${{ matrix.os }}.exe
+        path: target/${{ matrix.os }}/release/ka3005p.exe
+
+    - name: Upload binary
+      if: github.event_name == 'release' && matrix.os != 'x86_64-pc-windows-gnu'
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          asset_name: ka3005p-${{ matrix.os }}
+          asset_path: target/${{ matrix.os }}/release/ka3005p
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_content_type: application/octet-stream
+    - name: Upload Windows binary
+      if: github.event_name == 'release' && matrix.os == 'x86_64-pc-windows-gnu'
+      uses: actions/upload-release-asset@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          asset_name: ka3005p-${{ matrix.os }}.exe
+          asset_path: target/${{ matrix.os }}/release/ka3005p.exe
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_content_type: application/octet-stream
+
+    - name: Lint
+      uses: actions-rs/clippy-check@v1
+      with:
+          use-cross: true
+          name: clippy-${{ matrix.os }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features --target ${{ matrix.os }}
+          
+    - name: Tests
+      uses: actions-rs/cargo@v1
+      with:
+          use-cross: true
+          command: test
+          args: --target ${{ matrix.os }} --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.14.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+checksum = "dd0eaf8df8bab402257e0a5c17a254e4cc1f72a93588a1ddfb5d356c801aa7cb"
 dependencies = [
  "bitflags",
  "cc",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "3.3.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8d3ecaf58010bedccae17be55d4ed6f2ecde5646fc48ce8c66ea2d35a1419c"
+checksum = "22f37409d980045734250d679750bdf11bd875fec5bb5417dd21bb75d04d31a1"
 dependencies = [
  "CoreFoundation-sys",
  "IOKit-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["command-line-utilities"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serialport = "3.3.0"
+serialport = "4.0.0"
 structopt = "0.3.15"
 human-panic = "1.0.3"
 anyhow = "1.0.31"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SUBCOMMANDS:
     ocp        Enbale/Disable over current protection
     ovp        Enbale/Disable over voltage protection
     power      Turns on or off the ouput of the power supply
-    save       Saves current pannel settingts to specified config
+    save       Saves current pannel settings to specified config
     status     Return status inforation about the power spply
     voltage    Set the voltage of the ouput or config
 ```

--- a/examples/pwr.rs
+++ b/examples/pwr.rs
@@ -72,10 +72,9 @@ fn main() -> io::Result<()> {
             std::process::exit(1);
         }
         1 => {
-            let mut serial = serialport::open(&serial_devices[0].port_name).unwrap();
+            let mut serial = serialport::new(&serial_devices[0].port_name, 9600).open().unwrap();
 
             serial.set_timeout(time::Duration::from_millis(50)).unwrap();
-            serial.set_baud_rate(9600).unwrap();
             serial.set_parity(serialport::Parity::None).unwrap();
             serial.set_stop_bits(serialport::StopBits::One).unwrap();
 

--- a/src/bin/ka3005p.rs
+++ b/src/bin/ka3005p.rs
@@ -10,7 +10,7 @@ fn main() -> ::anyhow::Result<(), anyhow::Error> {
     let mut serial = ka3005p::find_serial_port()?;
     match args.command {
         ka3005p::cli::Command::Status => {
-            println!("{}", ka3005p::status(serial.as_mut())?);
+            println!("{}", serial.status()?);
         }
         ka3005p::cli::Command::Interactive => {
             for line in std::io::BufReader::new(std::io::stdin()).lines() {
@@ -18,8 +18,7 @@ fn main() -> ::anyhow::Result<(), anyhow::Error> {
                 let mut argv: Vec<&str> = normalized.split(' ').collect();
                 argv.insert(0, "ka3005p");
                 let arguments = ka3005p::cli::Ka3005p::from_iter(argv.into_iter());
-                ka3005p::execute(
-                    serial.as_mut(),
+                serial.execute(
                     arguments
                         .command
                         .clone()
@@ -29,8 +28,7 @@ fn main() -> ::anyhow::Result<(), anyhow::Error> {
             }
         }
         _ => {
-            ka3005p::execute(
-                serial.as_mut(),
+            serial.execute(
                 args.command
                     .clone()
                     .try_into()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,12 +12,12 @@ pub enum Command {
     /// Set the voltage of the ouput or config
     Voltage {
         #[structopt(help = "volts")]
-        v: crate::V,
+        v: f32,
     },
     /// Set the current of the ouput or config
     Current {
         #[structopt(help = "ampere")]
-        a: crate::I,
+        a: f32,
     },
     /// Saves current pannel settingts to specified config
     Save {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,7 +19,7 @@ pub enum Command {
         #[structopt(help = "ampere")]
         a: f32,
     },
-    /// Saves current pannel settingts to specified config
+    /// Saves current pannel settings to specified config
     Save {
         #[structopt(help = "1,2,3,4")]
         id: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ impl fmt::Display for Status {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Voltage: {}, Current: {}, Channel1: {:?}, Channel2: {:?} Lock: {:?}, Beep: {:?}, Output: {:?}",
+            "Voltage: {:.2}, Current: {:.3}, Channel1: {:?}, Channel2: {:?} Lock: {:?}, Beep: {:?}, Output: {:?}",
             self.voltage,
             self.current,
             self.flags.channel1,
@@ -200,7 +200,7 @@ impl std::convert::From<Command> for String {
             },
             Command::Save(id) => format!("SAV{}", id),
             Command::Load(id) => format!("RCL{}", id),
-            Command::Voltage(v) => format!("VSET1:{:.3}", v),
+            Command::Voltage(v) => format!("VSET1:{:.2}", v),
             Command::Current(i) => format!("ISET1:{:.3}", i),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,8 +211,8 @@ pub struct Ka3005p {
 }
 
 impl Ka3005p {
-    pub fn new(port_name: &String) -> anyhow::Result<Self> {
-        let serial = serialport::new(port_name.clone(), 9600)
+    pub fn new(port_name: &str) -> anyhow::Result<Self> {
+        let serial = serialport::new(port_name, 9600)
             .timeout(time::Duration::from_millis(50))
             .parity(serialport::Parity::None)
             .stop_bits(serialport::StopBits::One)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ pub struct Ka3005p {
 impl Ka3005p {
     pub fn new(port_name: &str) -> anyhow::Result<Self> {
         let serial = serialport::new(port_name, 9600)
-            .timeout(time::Duration::from_millis(50))
+            .timeout(time::Duration::from_millis(60))
             .parity(serialport::Parity::None)
             .stop_bits(serialport::StopBits::One)
             .open()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use std::time;
 
 pub mod cli;
+pub use serialport;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Switch {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,9 +221,8 @@ pub fn find_serial_port() -> anyhow::Result<Box<dyn serialport::SerialPort>> {
     match serial_devices.len() {
         0 => Err(anyhow::anyhow!("No Power Supply Found!")),
         1 => {
-            let mut serial = serialport::open(&serial_devices[0].port_name).unwrap();
+            let mut serial = serialport::new(&serial_devices[0].port_name, 9600).open().unwrap();
             serial.set_timeout(time::Duration::from_millis(50)).unwrap();
-            serial.set_baud_rate(9600).unwrap();
             serial.set_parity(serialport::Parity::None).unwrap();
             serial.set_stop_bits(serialport::StopBits::One).unwrap();
             Ok(serial)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,4 +313,46 @@ mod tests {
         assert_eq!(Switch::Off, Flags::new(0).output);
         assert_eq!(Switch::On, Flags::new(64).output);
     }
+
+    #[test]
+    fn test_output_vset() {
+        // PSU is picky on the number of decimal places.
+        assert_eq!(
+            String::from(Command::Voltage(3.123)),
+            "VSET1:3.12".to_string()
+        );
+        assert_eq!(
+            String::from(Command::Voltage(1.500)),
+            "VSET1:1.50".to_string()
+        );
+        assert_eq!(
+            String::from(Command::Voltage(4.999)),
+            "VSET1:5.00".to_string()
+        );
+        assert_eq!(
+            String::from(Command::Voltage(4.0)),
+            "VSET1:4.00".to_string()
+        );
+    }
+
+    #[test]
+    fn test_output_iset() {
+        // PSU is picky on the number of decimal places.
+        assert_eq!(
+            String::from(Command::Current(3.123)),
+            "ISET1:3.123".to_string()
+        );
+        assert_eq!(
+            String::from(Command::Current(1.500)),
+            "ISET1:1.500".to_string()
+        );
+        assert_eq!(
+            String::from(Command::Current(4.99999)),
+            "ISET1:5.000".to_string()
+        );
+        assert_eq!(
+            String::from(Command::Current(4.0)),
+            "ISET1:4.000".to_string()
+        );
+    }
 }


### PR DESCRIPTION
Thanks for the great library, saved me a bunch of time. The cli tool has become my go-to tool for these power supplies. 
I made a few changes to suit my use case, maybe these are useful to you. 

- There is now a `Ka3005p` object that creates/configures/contains the serial port. 
I spent some time debugging and found that I was passing a serial port with wonky setting, I think having the library manage this for you makes sense.
There is also a function to pass an already configured serialport if for whatever reason the user wants to customize the settings.

- Update serialport dependency to the latest `3.3.0` -> `4.0.0`

- Converted the `V` and `I` structs into `f32` to simplify the code.

- The `Flags` bitfields are now calculated as soon as it is created rather than having functions.
I benchmarked it on nightly and `Flags::new()` takes ~1.9ns (vs 60ms x 3 for the slow serial comms)

- Small typo fix from "settingts" to "settings" in the cli help